### PR TITLE
Fix nested attributes

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,15 +4,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # GET /resource/sign_up
   def new
-    super
+    resource = build_resource({})
     resource.user_instruments.build
+    respond_with resource
   end
 
   # POST /resource
-  def create
-    super
-    resource.user_instruments.build
-  end
+  # def create
+  #   super
+  # end
 
   # GET /resource/edit
   # def edit
@@ -42,7 +42,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:firstname, :surname, :user_instrument => [:instrument_id, :genre_id], :user_instruments => [:instrment_id, :genre_id]])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [
+      :firstname,
+      :surname,
+      :user_instruments_attributes => [:instrument_id, :genre_id]
+    ])
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,10 @@
 class User < ApplicationRecord
-  has_many :user_instruments
+  has_many :user_instruments, inverse_of: :user, dependent: :destroy
   has_many :user_comments
+
   accepts_nested_attributes_for :user_instruments
-    # Include default devise modules. Others available are:
+
+  # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -13,10 +13,12 @@
     </div>
 
     <div class="form-inputs col-md-6">
-      <h2>Your music</h2> 
-      <%= f.simple_fields_for :user_instrument do |user_instrument| %>
-      <%= user_instrument.collection_select :instrument_id, Instrument.all, :id, :name, prompt: true %>
-      <%= user_instrument.collection_select :genre_id, Genre.all, :id, :name, prompt: true %>
+      <h2>Your music</h2>
+      <%= f.simple_fields_for :user_instruments do |instrument| %>
+        <p>
+          <%= instrument.input :instrument_id, collection: Instrument.all, label_method: :name, value_method: :id, include_blank: false %>
+          <%= instrument.input :genre_id, collection: Genre.all, label_method: :name, value_method: :id, include_blank: false %>
+        </p>
       <% end %>
     </div>
 


### PR DESCRIPTION
Calling super before `resource.user_instruments.build` meant that the web request was already handled and returned to the browser early, if you look at what super does here:

https://github.com/plataformatec/devise/blob/master/app/controllers/devise/registrations_controller.rb#L8

You can see its going to `respond_with resource` - meaning the new view template is executed and rendered, before we had a chance to build any blank user_instruments.

To fix this I basically don’t call `super` and just inline the code from the original `Devise::RegistrationsController` above. Calling `resource.user_instruments.build` before we respond.

On top of that issue there were a couple of other things;

* The permitted signup params needed to be changed slightly.
* I changed the new view to use the simple form input (with collection) helpers, instead of `collection_select`
* To get the user_instrument to save correctly, I needed to add `inverse_of: :user` on the user association to user_instruments (I can explain why in our next call)

